### PR TITLE
Fix analyze warning in drawRect

### DIFF
--- a/MTLabel/MTLabel.m
+++ b/MTLabel/MTLabel.m
@@ -469,7 +469,8 @@ CGRect CTLineGetTypographicBoundsAsRect(CTLineRef line, CGPoint lineOrigin) {
 
     CGColorRef colorRef = CGColorCreate(CGColorSpaceCreateDeviceRGB(), CGColorGetComponents([_fontColor CGColor]));
     CGContextSetShadowWithColor(context, CGSizeMake(self.shadowOffset, self.shadowOffset), 5, colorRef);
-    
+    CGColorRelease(colorRef);
+	
     [self drawTextInRect:rect inContext:context];
     
     


### PR DESCRIPTION
MTLabel was failing Analyze due to colorRef in drawRect not being released.  One liner fix.
