### PR TITLE
Fix bug where setting font after lineHeight would reset lineHeight

### DIFF
--- a/MTLabel/MTLabel.m
+++ b/MTLabel/MTLabel.m
@@ -106,7 +106,9 @@ CGRect CTLineGetTypographicBoundsAsRect(CTLineRef line, CGPoint lineOrigin) {
         }
         
         _font = [font retain];
-        self._lineHeight = _font.lineHeight;
+        if (!self._lineHeight) {
+            self._lineHeight = _font.lineHeight;
+        }
         [self setNeedsDisplay];
         
     }


### PR DESCRIPTION
Was getting confused as to why the `lineHeight` property only seemed to work when my font size was 12. Thats because that was the default font, so the `setLineHeight:` code in `setFont:` didn't get run. Thus I discovered you need to set `lineHeight` _after_ you set `font`. Thats unintuitive, and this fixes it :) 
